### PR TITLE
Exclude executables from getting shims.

### DIFF
--- a/automatic/pluginval/tools/chocolateyInstall.ps1
+++ b/automatic/pluginval/tools/chocolateyInstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+$toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
+
 $packageName = $env:ChocolateyPackageName
 $url64       = ''
 $checksum64  = ''
@@ -14,3 +16,9 @@ $packageArgs = @{
   validExitCodes = @(0)
 }
 Install-ChocolateyZipPackage @packageArgs
+
+# Excludes pluginval from getting shims (https://docs.chocolatey.org/en-us/create/create-packages#how-do-i-exclude-executables-from-getting-shims)
+Get-ChildItem $toolsPath\*.exe | ForEach-Object { New-Item "$_.ignore" -type file -force | Out-Null }
+
+# Add pluginval to PATH
+Install-ChocolateyPath -PathToInstall $toolsPath -PathType User


### PR DESCRIPTION
Generates a .ignore file next to pluginval executable to prevent it from getting shims.
https://docs.chocolatey.org/en-us/create/create-packages#how-do-i-exclude-executables-from-getting-shims

Also adds the new location of pluginval to the user path.

![Capture](https://user-images.githubusercontent.com/6787157/107157082-6967b000-6982-11eb-8040-59bdd66afabc.png)

Directly Related to #2 