### PR TITLE
Updates FanFicFare to Add Plugin to Calibre

### DIFF
--- a/automatic/fanficfare/tools/chocolateyBeforeModify.ps1
+++ b/automatic/fanficfare/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'
+
+if (Get-Command "calibre-customize.exe" -ErrorAction SilentlyContinue) {
+  $pinfo                        = New-Object System.Diagnostics.ProcessStartInfo
+  $pinfo.FileName               = "calibre-customize.exe"
+  $pinfo.UseShellExecute        = $false
+  $pinfo.CreateNoWindow         = $true
+  $pinfo.RedirectStandardOutput = $true
+  $pinfo.RedirectStandardError  = $true
+
+  $pinfo.Arguments   = '--remove-plugin=FanFicFare'
+  $process           = New-Object System.Diagnostics.Process
+  $process.StartInfo = $pinfo
+
+  $null = $process.Start()
+  Write-Verbose($process.StandardOutput.ReadToEnd())
+} else {
+  Write-Error -Message 'calibre-customize.exe not found on path' -Category ResourceUnavailable
+}

--- a/automatic/fanficfare/tools/chocolateyInstall.ps1
+++ b/automatic/fanficfare/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 $url64       = ''
 $checksum64  = ''
@@ -9,7 +9,25 @@ $packageArgs = @{
   url64Bit       = $url64
   checksum64     = $checksum64
   checksumType64 = 'sha256'
-  unzipLocation  = Split-Path $MyInvocation.MyCommand.Definition
+  fileFullPath   = Join-Path (Split-Path $MyInvocation.MyCommand.Definition) "FanFicFarePlugin.zip"
   validExitCodes = @(0)
 }
-Install-ChocolateyZipPackage @packageArgs
+Get-ChocolateyWebFile @packageArgs
+
+if (Get-Command "calibre-customize.exe" -ErrorAction SilentlyContinue) {
+  $pinfo                        = New-Object System.Diagnostics.ProcessStartInfo
+  $pinfo.FileName               = "calibre-customize.exe"
+  $pinfo.UseShellExecute        = $false
+  $pinfo.CreateNoWindow         = $true
+  $pinfo.RedirectStandardOutput = $true
+  $pinfo.RedirectStandardError  = $true
+
+  $pinfo.Arguments   = '--add-plugin={0}' -f $packageArgs.fileFullPath
+  $process           = New-Object System.Diagnostics.Process
+  $process.StartInfo = $pinfo
+
+  $null = $process.Start()
+  Write-Verbose($process.StandardOutput.ReadToEnd())
+} else {
+  Write-Error -Message 'calibre-customize.exe not found on path' -Category ResourceUnavailable
+}


### PR DESCRIPTION
This should solve the issue mentioned in the [CCR moderation queue](https://community.chocolatey.org/packages/fanficfare).

I quickly tested install and uninstall; It seems to add and remove from Calibre properly.

As the files seem to be imported into Calibre's working directories, we could clean up the downloaded zip at the end - but it's not large, so this probably isn't a worry.

We could also consider adding a Calibre dependency to the package? I don't know if anyone would potentially use this package to just download the files. If so, I've changed the structure of the tools directory in this PR - but felt as it currently didn't have any approved versions, this would be alright.